### PR TITLE
More dating app features

### DIFF
--- a/plugins/dateprof/commands/swipe_cmd.rb
+++ b/plugins/dateprof/commands/swipe_cmd.rb
@@ -2,7 +2,7 @@ module AresMUSH
   module DateProf
     class SwipeCmd
       include CommandHandler
-      include DateProf::SwipeType
+      include SwipeCommandHandler
 
       attr_accessor :name, :type
 
@@ -16,12 +16,6 @@ module AresMUSH
         else
           self.type = swipe_type_arg(cmd.args)
         end
-      end
-
-      def check_enactor
-        return t('dateprof.must_be_approved') unless enactor.is_approved?
-        return t('dateprof.admin_no_swiping') if enactor.is_admin?
-        return nil
       end
 
       def check_type

--- a/plugins/dateprof/commands/swipe_list_cmd.rb
+++ b/plugins/dateprof/commands/swipe_list_cmd.rb
@@ -2,17 +2,12 @@ module AresMUSH
   module DateProf
     class SwipeListCmd
       include CommandHandler
-      include SwipeType
+      include SwipeCommandHandler
 
       attr_accessor :type
 
       def parse_args
         self.type = swipe_type_arg(cmd.args) unless cmd.args.blank?
-      end
-
-      def check_admin
-        return t('dateprof.admin_no_swiping') if enactor.is_admin?
-        return nil
       end
 
       def check_type

--- a/plugins/dateprof/commands/swipe_matches_cmd.rb
+++ b/plugins/dateprof/commands/swipe_matches_cmd.rb
@@ -2,11 +2,7 @@ module AresMUSH
   module DateProf
     class SwipeMatchesCmd
       include CommandHandler
-
-      def check_admin
-        return t('dateprof.admin_no_swiping') if enactor.is_admin?
-        return nil
-      end
+      include SwipeCommandHandler
 
       def handle
         title = "#{enactor_name}'s Matches"

--- a/plugins/dateprof/helpers.rb
+++ b/plugins/dateprof/helpers.rb
@@ -13,7 +13,7 @@ module AresMUSH
     end
 
     def self.can_swipe?(actor)
-      actor && actor.is_approved? && !actor.is_admin?
+      actor && actor.is_approved? && !actor.is_admin? && !actor.is_playerbit?
     end
   end
 end

--- a/plugins/dateprof/helpers.rb
+++ b/plugins/dateprof/helpers.rb
@@ -15,5 +15,13 @@ module AresMUSH
     def self.can_swipe?(actor)
       actor && actor.is_approved? && !actor.is_admin? && !actor.is_playerbit?
     end
+
+    def self.swiping_demographics
+      Global.read_config('dateprof', 'demographics') || ['gender']
+    end
+
+    def self.swiping_groups
+      Global.read_config('dateprof', 'groups') || []
+    end
   end
 end

--- a/plugins/dateprof/helpers.rb
+++ b/plugins/dateprof/helpers.rb
@@ -1,9 +1,19 @@
 module AresMUSH
   module DateProf
-    module SwipeType
+    module SwipeCommandHandler
+      def check_enactor
+        return t('dateprof.must_be_approved') unless enactor.is_approved?
+        return t('dateprof.swiper_no_swiping') unless DateProf.can_swipe?(enactor)
+        return nil
+      end
+
       def swipe_type_arg(arg)
         downcase_arg(arg).sub(' ','_').to_sym
       end
+    end
+
+    def self.can_swipe?(actor)
+      actor && actor.is_approved? && !actor.is_admin?
     end
   end
 end

--- a/plugins/dateprof/locales/locale_en.yml
+++ b/plugins/dateprof/locales/locale_en.yml
@@ -5,7 +5,7 @@ en:
     dateprof_title: "Dating Profile"
     invalid_swipe_type: "Invalid swipe type. It must be one of: interested, curious, skip, or missed connection."
     no_more_profiles: "You have swiped on everybody! Take a break."
-    admin_no_swiping: "Admins can't swipe."
+    swiper_no_swiping: "You are not allowed to swipe."
     must_be_approved: "You must be approved to swipe."
     missed_must_swipe: "You must swipe Interested or Curious before marking a missed connection."
     already_matched: "You cannot mark a missed connection for a player with whom you have a match."

--- a/plugins/dateprof/public/swipe_char.rb
+++ b/plugins/dateprof/public/swipe_char.rb
@@ -17,10 +17,8 @@ module AresMUSH
     end
 
     def refresh_dating_queue!
-      queue = Character.all.reject(&:is_admin?).select(&:is_approved?).reject do |model|
-        model.id == self.id
-      end.select do |model|
-        swipe_for(model).nil?
+      queue = Character.all.select do |model|
+        model.id != self.id && DateProf.can_swipe?(model) && swipe_for(model).nil?
       end.shuffle
       self.dating_queue.replace(queue)
     end

--- a/plugins/dateprof/web/dating_app_request_handler.rb
+++ b/plugins/dateprof/web/dating_app_request_handler.rb
@@ -4,14 +4,11 @@ module AresMUSH
       attr_accessor :enactor
 
       def handle(request)
+        self.enactor = request.enactor
         error = Website.check_login(request)
         return error if error
-
-        if request.enactor.is_admin?
-          return {error: t('dateprof.admin_no_swiping')}
-        end
-
-        self.enactor = request.enactor
+        return {error: t('dateprof.must_be_approved')} unless enactor.is_approved?
+        return {error: t('dateprof.swiper_no_swiping')} unless DateProf.can_swipe?(enactor)
         {
           profile: profile,
           swipes: swipes,

--- a/plugins/dateprof/web/dating_app_request_handler.rb
+++ b/plugins/dateprof/web/dating_app_request_handler.rb
@@ -18,7 +18,17 @@ module AresMUSH
 
       def profile
         char = enactor.next_dating_profile
-        format_char(char) unless char.nil?
+        return nil if char.nil?
+        format_char(char).tap do |dict|
+          facts = []
+          DateProf.swiping_demographics.each do |key|
+            facts << {name: key.titlecase, value: char.demographics[key]}
+          end
+          DateProf.swiping_groups.each do |key|
+            facts << {name: key.titlecase, value: char.groups[key]}
+          end
+          dict[:facts] = facts
+        end
       end
 
       def swipes

--- a/plugins/dateprof/web/dating_app_request_handler.rb
+++ b/plugins/dateprof/web/dating_app_request_handler.rb
@@ -31,9 +31,11 @@ module AresMUSH
       end
 
       def matches
-        enactor.matches.map do |type, characters|
-          format_char_list(type, characters)
-        end
+        m = enactor.matches
+        [:solid, :okay, :maybe, :missed_connection].map do |type|
+          next unless m[type]
+          format_char_list(type, m[type])
+        end.compact
       end
 
       private

--- a/plugins/dateprof/web/match_for_request_handler.rb
+++ b/plugins/dateprof/web/match_for_request_handler.rb
@@ -11,10 +11,7 @@ module AresMUSH
 
         error = Website.check_login(request, true)
         return error if error
-
-        if (enactor.is_admin?)
-          return {}
-        end
+        return {} unless DateProf.can_swipe?(enactor)
 
         match = enactor.match_for(char)
         swipe = enactor.swipe_for(char)

--- a/plugins/dateprof/web/swipe_for_request_handler.rb
+++ b/plugins/dateprof/web/swipe_for_request_handler.rb
@@ -10,6 +10,8 @@ module AresMUSH
 
         error = Website.check_login(request, true)
         return error if error
+        return {error: t('dateprof.must_be_approved')} unless enactor.is_approved?
+        return {error: t('dateprof.swiper_no_swiping')} unless DateProf.can_swipe?(enactor)
 
         type = request.args[:type].to_sym
         error = Swipe.check_type(type)

--- a/plugins/dateprof/web/swipe_for_request_handler.rb
+++ b/plugins/dateprof/web/swipe_for_request_handler.rb
@@ -10,6 +10,8 @@ module AresMUSH
 
         error = Website.check_login(request, true)
         return error if error
+
+        enactor = request.enactor
         return {error: t('dateprof.must_be_approved')} unless enactor.is_approved?
         return {error: t('dateprof.swiper_no_swiping')} unless DateProf.can_swipe?(enactor)
 
@@ -17,7 +19,6 @@ module AresMUSH
         error = Swipe.check_type(type)
         return { error: error } if error
 
-        enactor = request.enactor
         error = enactor.swipe(char, type)
         return { error: error } if error
         match = enactor.match_for(char)

--- a/plugins/login/web/check_token_request_handler.rb
+++ b/plugins/login/web/check_token_request_handler.rb
@@ -37,7 +37,8 @@ module AresMUSH
           is_approved: char.is_approved?,
           is_admin: char.is_admin?,
           is_coder: char.is_coder?,
-          is_wiki_mgr: (!char.is_admin? && Website.can_manage_theme?(char))
+          is_wiki_mgr: (!char.is_admin? && Website.can_manage_theme?(char)),
+          can_swipe: DateProf.can_swipe?(char),
         }
       end
     end

--- a/plugins/login/web/login_request_handler.rb
+++ b/plugins/login/web/login_request_handler.rb
@@ -51,7 +51,8 @@ module AresMUSH
           is_approved: char.is_approved?,
           is_admin: char.is_admin?,
           is_coder: char.is_coder?,
-          is_wiki_mgr: (!char.is_admin? && Website.can_manage_theme?(char))
+          is_wiki_mgr: (!char.is_admin? && Website.can_manage_theme?(char)),
+          can_swipe: DateProf.can_swipe?(char),
         }
       end
     end

--- a/plugins/profile/custom_char_fields.rb
+++ b/plugins/profile/custom_char_fields.rb
@@ -6,7 +6,10 @@ module AresMUSH
       # Note: Viewer may be nil if someone's looking at the character page without being logged in
       # Example: return { goals: Website.format_markdown_for_html(char.goals) }
       def self.get_fields_for_viewing(char, viewer)
-        return { dateprof: Website.format_markdown_for_html(char.dateprof), isAdmin: char.is_admin? }
+        return {
+          dateprof: Website.format_markdown_for_html(char.dateprof),
+          canSwipe: DateProf::can_swipe?(char),
+        }
       end
     
       # Return a hash of custom fields formatted for editing in the profile editor


### PR DESCRIPTION
This includes:
- Disallowing playerbits from swiping.
- Making sure matches show up in sorted order: solid, okay, maybe, missed connection.
- Sending demographic and group information to the web portal for swiping.

In addition to deploying the code, configuration needs to be added under the `dateprof` key indicating which demographics and groups should be included on the swiping page. I already added them to `dateprof.yml`.