### PR TITLE
show dating profile in appropriate cases

### DIFF
--- a/plugins/dateprof/helpers.rb
+++ b/plugins/dateprof/helpers.rb
@@ -18,7 +18,7 @@ module AresMUSH
 
     def self.show_dating_profile?(enactor, char)
       return true if can_swipe?(char)
-      return false if char.is_playerbit?
+      return false if char.is_admin? or char.is_playerbit?
       return true if Chargen.can_approve?(enactor) and !char.is_approved?
       return false
     end

--- a/plugins/dateprof/helpers.rb
+++ b/plugins/dateprof/helpers.rb
@@ -16,6 +16,13 @@ module AresMUSH
       actor && actor.is_approved? && !actor.is_admin? && !actor.is_playerbit?
     end
 
+    def self.show_dating_profile?(enactor, char)
+      return true if can_swipe?(char)
+      return false if char.is_playerbit?
+      return true if Chargen.can_approve?(enactor) and !char.is_approved?
+      return false
+    end
+
     def self.swiping_demographics
       Global.read_config('dateprof', 'demographics') || ['gender']
     end

--- a/plugins/profile/custom_char_fields.rb
+++ b/plugins/profile/custom_char_fields.rb
@@ -8,7 +8,7 @@ module AresMUSH
       def self.get_fields_for_viewing(char, viewer)
         return {
           dateprof: Website.format_markdown_for_html(char.dateprof),
-          canSwipe: DateProf::can_swipe?(char),
+          showDateProf: DateProf.show_dating_profile?(viewer, char),
         }
       end
     
@@ -37,7 +37,6 @@ module AresMUSH
         char.update(dateprof: chargen_data[:custom][:dateprof])
         return []
       end
-      
     end
   end
 end

--- a/plugins/profile/templates/profile.erb
+++ b/plugins/profile/templates/profile.erb
@@ -33,8 +33,8 @@
 <%= divider %>
 %xh<%= left( t('profile.handle'), 12 ) %>%xn @<%= handle_name %> - <%= handle_profile %>
 <% end %>
+<% if show_dating_profile? %>
 <%= line_with_text "Dating Profile" %>
-<% unless @char.is_admin? %>
 <%= dating_profile %>
 <% end %>
 <% if dating_match? or dating_swipe? %>

--- a/plugins/profile/templates/profile_template.rb
+++ b/plugins/profile/templates/profile_template.rb
@@ -19,6 +19,10 @@ module AresMUSH
         Demographics.visible_demographics(@char, @enactor).select { |d| d != 'birthdate' }
       end
 
+      def show_dating_profile?
+        DateProf.show_dating_profile?(@enactor, @char)
+      end
+
       def dating_match?
         @enactor.match_for(@char)
       end


### PR DESCRIPTION
In most cases, people who can't swipe shouldn't have a dating profile
tab on their profile page. But, unapproved characters can't swipe, and
staff needs to be able to view their dating profile tab.