### PR TITLE
Dating tweaks

### DIFF
--- a/plugins/dateprof/dateprof.rb
+++ b/plugins/dateprof/dateprof.rb
@@ -39,10 +39,10 @@ module AresMUSH
 
         def self.get_web_request_handler(request)
             case request.cmd
-            when "altMatches"
-              return AltMatchesRequestHandler
             when "datingApp"
               return DatingAppRequestHandler
+            when "datingSummary"
+              return DatingSummaryRequestHandler
             when "matchFor"
               return MatchForRequestHandler
             when "showOrHideAlts"

--- a/plugins/dateprof/helpers.rb
+++ b/plugins/dateprof/helpers.rb
@@ -22,6 +22,12 @@ module AresMUSH
       actor && actor.is_approved? && !actor.is_admin? && !actor.is_playerbit?
     end
 
+    def self.show_dating_profile?(char, viewer)
+      return true if char.name == viewer.name
+      return true if Chargen.can_approve?(viewer)
+      can_swipe?(char)
+    end
+
     def self.swiping_demographics
       Global.read_config('dateprof', 'demographics') || ['gender']
     end

--- a/plugins/dateprof/web/dating_summary_request_handler.rb
+++ b/plugins/dateprof/web/dating_summary_request_handler.rb
@@ -1,6 +1,6 @@
 module AresMUSH
   module DateProf
-    class AltMatchesRequestHandler
+    class DatingSummaryRequestHandler
       def handle(request)
         error = Website.check_login(request, true)
         return error if error

--- a/plugins/dateprof/web/dating_summary_request_handler.rb
+++ b/plugins/dateprof/web/dating_summary_request_handler.rb
@@ -15,6 +15,7 @@ module AresMUSH
         end.map do |alt|
           {
             char: DateProf.format_char(alt),
+            hasUnswipedCharacters: !!alt.next_dating_profile,
             matches: DateProf.format_matches(alt.matches),
           }
         end

--- a/plugins/profile/custom_char_fields.rb
+++ b/plugins/profile/custom_char_fields.rb
@@ -8,7 +8,7 @@ module AresMUSH
       def self.get_fields_for_viewing(char, viewer)
         return {
           dateprof: Website.format_markdown_for_html(char.dateprof),
-          canSwipe: DateProf::can_swipe?(char),
+          showDatingProfile: DateProf::show_dating_profile?(char, viewer),
         }
       end
     


### PR DESCRIPTION
This PR includes two things:

1. Correctly display the Dating Profile tab when it should be shown.
2. Indicate in the dating summary when an alt has unswiped characters.