### PR TITLE
sort characters alphabetically on dating app pages

### DIFF
--- a/plugins/dateprof/helpers.rb
+++ b/plugins/dateprof/helpers.rb
@@ -50,7 +50,7 @@ module AresMUSH
       {
         name: type.to_s.humanize.titlecase,
         key: type,
-        characters: characters.map {|char| format_char(char)}
+        characters: characters.sort {|a,b| a.name <=> b.name}.map {|char| format_char(char)}
       }
     end
 


### PR DESCRIPTION
A very simple change to sort characters alphabetically in the lists on both of the dating tabs. There are no changes for the web portal. Should just be able to `load dateprof` after updating the code.