### PR TITLE
add canSwipe to custom profile fields

### DIFF
--- a/plugins/profile/custom_char_fields.rb
+++ b/plugins/profile/custom_char_fields.rb
@@ -9,6 +9,7 @@ module AresMUSH
         return {
           dateprof: Website.format_markdown_for_html(char.dateprof),
           showDatingProfile: DateProf::show_dating_profile?(char, viewer),
+          canSwipe: DateProf::can_swipe?(char),
         }
       end
     


### PR DESCRIPTION
This is to enable a fix in the web portal for the situation where admins with dating alts can swipe on unapproved characters.