### PR TITLE
optimize DateProf.can_swipe?

### DIFF
--- a/plugins/chargen/commands/app_unapprove_cmd.rb
+++ b/plugins/chargen/commands/app_unapprove_cmd.rb
@@ -28,6 +28,7 @@ module AresMUSH
           model.update(approval_job: nil)
           model.update(chargen_locked: false)
           Roles.remove_role(model, "approved")
+          Chargen.custom_unapproval(model)
           client.emit_success t('chargen.app_unapproved', :name => model.name)
         end
       end

--- a/plugins/chargen/custom_approval.rb
+++ b/plugins/chargen/custom_approval.rb
@@ -1,20 +1,11 @@
 module AresMUSH
   module Chargen
     def self.custom_approval(char)
-            
-      # If you don't want to have any custom approval steps, just leave this blank.
-      
-      # Otherwise, do what you need to do.  Here's an example of how to add
-      # someone to a role based on their faction:
-      #
-      #  faction = char.group("Faction")
-      #  role = Role.find_by_name(faction)
-      #
-      #  if (role)
-      #    char.roles.add role
-      #  end
-      #
-      # See https://www.aresmush.com/tutorials/config/chargen.html for details.
+      char.update(can_swipe: true)
+    end
+
+    def self.custom_unapproval(char)
+      char.update(can_swipe: false)
     end
   end
 end

--- a/plugins/dateprof/helpers.rb
+++ b/plugins/dateprof/helpers.rb
@@ -19,7 +19,7 @@ module AresMUSH
     end
 
     def self.can_swipe?(actor)
-      actor && actor.is_active? && actor.is_approved?
+      actor && actor.can_swipe && actor.idle_state.nil? && !actor.is_npc
     end
 
     def self.can_swipe_in_portal?(actor)

--- a/plugins/dateprof/public/swipe_char.rb
+++ b/plugins/dateprof/public/swipe_char.rb
@@ -3,6 +3,7 @@ module AresMUSH
     list :dating_queue, 'AresMUSH::Character'
     collection :swipes, 'AresMUSH::DateProf::Swipe'
     attribute :hide_alts, :type=> DataType::Boolean, :default => false
+    attribute :can_swipe, :type=> DataType::Boolean, :default => false
 
     def dating_alts
       @dating_alts ||= self.alts.select {|alt| DateProf.can_swipe?(alt)}.sort {|a,b| a.name <=> b.name}

--- a/plugins/dateprof/web/dating_app_request_handler.rb
+++ b/plugins/dateprof/web/dating_app_request_handler.rb
@@ -9,9 +9,9 @@ module AresMUSH
         dater = Character.find_one_by_name(request.args[:dater])
         dater ||= DateProf.can_swipe?(enactor) ? enactor : enactor.dating_alts.first
 
+        return {error: t('dateprof.swiper_no_swiping')} unless DateProf.can_swipe?(dater)
         return {error: t('dateprof.not_your_alt')} unless AresCentral.is_alt?(dater, enactor)
         return {error: t('dateprof.must_be_approved')} unless dater.is_approved?
-        return {error: t('dateprof.swiper_no_swiping')} unless DateProf.can_swipe?(dater)
 
         build_dating_app_web_data(dater)
       end


### PR DESCRIPTION
This results in a significant speedup all over the dating app pages because it turns out this was expensive and it gets used to check characters everywhere.

First, you need to load multiple modules with this update:
```
load chargen
load dateprof
```

Then you need to run a ruby oneliner:
```ruby
ruby Character.all.each {|c| c.update(can_swipe: c.is_approved? && !c.is_admin? && !c.is_playerbit?)}
```