### PR TITLE
track match status on swipes

### DIFF
--- a/plugins/dateprof/public/swipe.rb
+++ b/plugins/dateprof/public/swipe.rb
@@ -7,6 +7,7 @@ module AresMUSH
       reference :target, 'AresMUSH::Character'
       attribute :type, :type => DataType::Symbol
       attribute :missed, :type => DataType::Boolean, :default => false
+      attribute :match, :type => DataType::Symbol
 
       index :type
       index :missed


### PR DESCRIPTION
When displaying matches, we look up both swipes involved and calculate the match value with them. However, that value only changes when swipes are _made_ and so there's no reason to be doing so many database queries. This change adds a `match` attribute to the Swipe model and then makes sure it gets correctly updated when swipes are made or missed connections are marked.

After the code is loaded, the following ruby oneliner needs to be run:
```ruby
ruby AresMUSH::DateProf::Swipe.all.each {|s| s.update(match: DateProf.match_for_swipes(s, s.target.swipe_for(s.character)))}
```